### PR TITLE
Checksum uniqueness

### DIFF
--- a/image/src/main/kotlin/com/lukasz/witkowski/training/planner/image/infrastructure/db/DbImageReference.kt
+++ b/image/src/main/kotlin/com/lukasz/witkowski/training/planner/image/infrastructure/db/DbImageReference.kt
@@ -8,6 +8,5 @@ internal data class DbImageReference(
     @PrimaryKey
     val id: String,
     val path: String,
-    // TODO this column should be unique
     val checksum: Long
 )


### PR DESCRIPTION
Remove TODO.
The checksum uniqueness is handled inside the application layer. The additional saved file does not cause as many issues as overwriting the existing images.